### PR TITLE
esp-idf 5.x fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,29 @@ set(ATOMVM_NEOPIXEL_COMPONENT_SRCS
     "nifs/led_strip_rmt_ws2812.c"
 )
 
+if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
+    set(ADDITIONAL_PRIV_REQUIRES "esp_hw_support" "efuse")
+else()
+    set(ADDITIONAL_PRIV_REQUIRES "")
+endif()
+
+# WHOLE_ARCHIVE option is supported only with esp-idf 5.x
+# A link option will be used with esp-idf 4.x
+if (IDF_VERSION_MAJOR EQUAL 5)
+    set(OPTIONAL_WHOLE_ARCHIVE WHOLE_ARCHIVE)
+else()
+    set(OPTIONAL_WHOLE_ARCHIVE "")
+endif()
+
 idf_component_register(
     SRCS ${ATOMVM_NEOPIXEL_COMPONENT_SRCS}
     INCLUDE_DIRS "nifs/include"
-    PRIV_REQUIRES "libatomvm" "avm_sys" "driver"
+    PRIV_REQUIRES "libatomvm" "avm_sys" "driver" ${ADDITIONAL_PRIV_REQUIRES}
+    ${OPTIONAL_WHOLE_ARCHIVE}
 )
 
-idf_build_set_property(
-    LINK_OPTIONS "-Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a -Wl,--no-whole-archive"
-    APPEND
-)
+if (IDF_VERSION_MAJOR EQUAL 4)
+    idf_build_set_property(
+        LINK_OPTIONS "-Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a -Wl,--no-whole-archive"
+        APPEND)
+endif()


### PR DESCRIPTION
copy pasted from the avm_builtins CMakeLists

compiles and tested on hardware.